### PR TITLE
Patch for GDR pointer errors addresses #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Python tools to read waveform and geolocated elevation data from the ESA CryoSat
 - [`read_shapefile.py`](https://github.com/tsutterley/read-cryosat-2/blob/master/doc/source/user_guide/read_shapefile.md): Reads polygons from ESRI shapefiles  
 
 #### Dependencies
-- [numpy: Scientific Computing Tools For Python](http://www.numpy.org)  
-- [scipy: Scientific Tools for Python](http://www.scipy.org/)  
+- [numpy: Scientific Computing Tools For Python](https://numpy.org)  
+- [scipy: Scientific Tools for Python](https://docs.scipy.org/doc//)  
 - [h5py: Python interface for Hierarchal Data Format 5 (HDF5)](http://h5py.org)  
 - [netCDF4: Python interface to the netCDF C library](https://unidata.github.io/netcdf4-python/netCDF4/index.html)  
 - [gdal: Pythonic interface to the Geospatial Data Abstraction Library (GDAL)](https://pypi.python.org/pypi/GDAL)  

--- a/cryosat_toolkit/HDF5_cryosat_L1b.py
+++ b/cryosat_toolkit/HDF5_cryosat_L1b.py
@@ -24,9 +24,9 @@ OPTIONS:
     ATTRIBUTES (read_HDF5_cryosat_L1b): input variable attributes from HDF5 file
 
 PYTHON DEPENDENCIES:
-    numpy: Scientific Computing Tools For Python (http://www.numpy.org)
+    numpy: Scientific Computing Tools For Python (https://numpy.org)
     h5py: Python interface for Hierarchal Data Format 5 (HDF5)
-        (http://h5py.org)
+        (https://www.h5py.org/)
 
 UPDATE HISTORY:
     Updated 02/2020: convert from hard to soft tabulation

--- a/cryosat_toolkit/HDF5_cryosat_L2.py
+++ b/cryosat_toolkit/HDF5_cryosat_L2.py
@@ -22,9 +22,9 @@ OPTIONS:
     ATTRIBUTES (read_HDF5_cryosat_L2): input variable attributes from HDF5 file
 
 PYTHON DEPENDENCIES:
-    numpy: Scientific Computing Tools For Python (http://www.numpy.org)
+    numpy: Scientific Computing Tools For Python (https://numpy.org)
     h5py: Python interface for Hierarchal Data Format 5 (HDF5)
-        (http://h5py.org)
+        (https://www.h5py.org/)
 
 UPDATE HISTORY:
     Updated 02/2020: convert from hard to soft tabulation

--- a/cryosat_toolkit/HDF5_cryosat_L2I.py
+++ b/cryosat_toolkit/HDF5_cryosat_L2I.py
@@ -24,9 +24,9 @@ OPTIONS:
     ATTRIBUTES (read_HDF5_cryosat_L2I): input variable attributes from HDF5 file
 
 PYTHON DEPENDENCIES:
-    numpy: Scientific Computing Tools For Python (http://www.numpy.org)
+    numpy: Scientific Computing Tools For Python (https://numpy.org)
     h5py: Python interface for Hierarchal Data Format 5 (HDF5)
-        (http://h5py.org)
+        (https://www.h5py.org/)
 
 UPDATE HISTORY:
     Updated 02/2020: convert from hard to soft tabulation

--- a/cryosat_toolkit/calc_GPS_time.py
+++ b/cryosat_toolkit/calc_GPS_time.py
@@ -13,7 +13,7 @@ INPUTS:
     micsec: microseconds portion of date variable
 
 PYTHON DEPENDENCIES:
-    numpy: Scientific Computing Tools For Python (http://www.numpy.org)
+    numpy: Scientific Computing Tools For Python (https://numpy.org)
 
 UPDATE HISTORY:
     Written 10/2017

--- a/cryosat_toolkit/read_cryosat_L1b.py
+++ b/cryosat_toolkit/read_cryosat_L1b.py
@@ -20,8 +20,8 @@ OUTPUTS:
 
 PYTHON DEPENDENCIES:
     numpy: Scientific Computing Tools For Python
-        http://www.numpy.org
-        http://www.scipy.org/NumPy_for_Matlab_Users
+        https://numpy.org
+        https://numpy.org/doc/stable/user/numpy-for-matlab-users.html
     netCDF4: Python interface to the netCDF C library
         https://unidata.github.io/netcdf4-python/netCDF4/index.html
 

--- a/cryosat_toolkit/read_cryosat_L2I.py
+++ b/cryosat_toolkit/read_cryosat_L2I.py
@@ -20,10 +20,10 @@ OUTPUTS:
 
 PYTHON DEPENDENCIES:
     numpy: Scientific Computing Tools For Python
-        http://www.numpy.org
-        http://www.scipy.org/NumPy_for_Matlab_Users
+        https://numpy.org
+        https://numpy.org/doc/stable/user/numpy-for-matlab-users.html
     scipy: Scientific Tools for Python
-        http://www.scipy.org/
+        https://docs.scipy.org/doc/
     netCDF4: Python interface to the netCDF C library
         https://unidata.github.io/netcdf4-python/netCDF4/index.html
 

--- a/cryosat_toolkit/read_geojson_file.py
+++ b/cryosat_toolkit/read_geojson_file.py
@@ -16,8 +16,8 @@ OPTIONS:
 
 PYTHON DEPENDENCIES:
     numpy: Scientific Computing Tools For Python
-        http://www.numpy.org
-        http://www.scipy.org/NumPy_for_Matlab_Users
+        https://numpy.org
+        https://numpy.org/doc/stable/user/numpy-for-matlab-users.html
     fiona: Python wrapper for vector data access functions from the OGR library
         https://fiona.readthedocs.io/en/latest/manual.html
     geopandas: Python tools for geographic data

--- a/cryosat_toolkit/read_kml_file.py
+++ b/cryosat_toolkit/read_kml_file.py
@@ -17,8 +17,8 @@ OPTIONS:
 
 PYTHON DEPENDENCIES:
     numpy: Scientific Computing Tools For Python
-        http://www.numpy.org
-        http://www.scipy.org/NumPy_for_Matlab_Users
+        https://numpy.org
+        https://numpy.org/doc/stable/user/numpy-for-matlab-users.html
     gdal: Pythonic interface to the Geospatial Data Abstraction Library (GDAL)
         https://pypi.python.org/pypi/GDAL/
     fiona: Python wrapper for vector data access functions from the OGR library

--- a/cryosat_toolkit/read_shapefile.py
+++ b/cryosat_toolkit/read_shapefile.py
@@ -17,8 +17,8 @@ OPTIONS:
 
 PYTHON DEPENDENCIES:
     numpy: Scientific Computing Tools For Python
-        http://www.numpy.org
-        http://www.scipy.org/NumPy_for_Matlab_Users
+        https://numpy.org
+        https://numpy.org/doc/stable/user/numpy-for-matlab-users.html
     fiona: Python wrapper for vector data access functions from the OGR library
         https://fiona.readthedocs.io/en/latest/manual.html
     shapely: PostGIS-ish operations outside a database context for Python

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2020, Tyler C. Sutterley'
 author = 'Tyler C. Sutterley'
 
 # The full version, including alpha/beta/rc tags
-release = '1.0.1.4'
+release = '1.0.1.5'
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/source/getting_started/Citations.md
+++ b/doc/source/getting_started/Citations.md
@@ -13,8 +13,8 @@ Altimetry Data from ICESat and CryoSat-2". *Remote Sensing*, 10(11): 1817, 2018.
 
 #### Dependencies
 This software is also dependent on other commonly used Python packages:
-- [numpy: Scientific Computing Tools For Python](http://www.numpy.org)  
-- [scipy: Scientific Tools for Python](http://www.scipy.org/)  
+- [numpy: Scientific Computing Tools For Python](https://numpy.org)  
+- [scipy: Scientific Tools for Python](https://docs.scipy.org/doc//)  
 - [h5py: Python interface for Hierarchal Data Format 5 (HDF5)](http://h5py.org)  
 - [netCDF4: Python interface to the netCDF C library](https://unidata.github.io/netcdf4-python/netCDF4/index.html)  
 - [gdal: Pythonic interface to the Geospatial Data Abstraction Library (GDAL)](https://pypi.python.org/pypi/GDAL)  

--- a/doc/source/getting_started/Install.md
+++ b/doc/source/getting_started/Install.md
@@ -1,7 +1,7 @@
 Installation
 ============
 
-Presently read-cryosat-2 is only available for use as a [github repository](https://github.com/tsutterley/read-cryosat-2).
+Presently read-cryosat-2 is only available for use as a [GitHub repository](https://github.com/tsutterley/read-cryosat-2).
 The contents of the repository can be download as a [zipped file](https://github.com/tsutterley/read-cryosat-2/archive/master.zip)  or cloned.
 To use this repository, please fork into your own account and then clone onto your system.  
 ```bash
@@ -9,10 +9,16 @@ git clone https://github.com/tsutterley/read-cryosat-2.git
 ```
 Can then install using `setuptools`
 ```bash
-python setup.py install
+python3 setup.py install
 ```
 or `pip`
 ```bash
-pip install --user .
+python3 -m pip install --user .
 ```
+
+Alternatively can install the cryosat_toolkit utilities from GitHub with `pip`
+```bash
+python3 -m pip install --user git+https://github.com/tsutterley/read-cryosat-2.git
+```
+
 Executable versions of this repository can also be tested using [Binder](https://mybinder.org/v2/gh/tsutterley/read-cryosat-2/master) and [Pangeo](https://binder.pangeo.io/v2/gh/tsutterley/read-cryosat-2/master).

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: example-environment
+name: read-cryosat-2
 channels:
   - conda-forge
 dependencies:

--- a/esa_cryosat_ftp.py
+++ b/esa_cryosat_ftp.py
@@ -33,11 +33,11 @@ COMMAND LINE OPTIONS:
 
 PYTHON DEPENDENCIES:
     lxml: Pythonic XML and HTML processing library using libxml2/libxslt
-        http://lxml.de/
+        https://lxml.de/
         https://github.com/lxml/lxml
     numpy: Scientific Computing Tools For Python
-        http://www.numpy.org
-        http://www.scipy.org/NumPy_for_Matlab_Users
+        https://numpy.org
+        https://numpy.org/doc/stable/user/numpy-for-matlab-users.html
     gdal: Pythonic interface to the Geospatial Data Abstraction Library (GDAL)
         https://pypi.python.org/pypi/GDAL/
     fiona: Python wrapper for vector data access functions from the OGR library

--- a/esa_cryosat_sync.py
+++ b/esa_cryosat_sync.py
@@ -31,11 +31,11 @@ COMMAND LINE OPTIONS:
 
 PYTHON DEPENDENCIES:
     lxml: Pythonic XML and HTML processing library using libxml2/libxslt
-        http://lxml.de/
+        https://lxml.de/
         https://github.com/lxml/lxml
     numpy: Scientific Computing Tools For Python
-        http://www.numpy.org
-        http://www.scipy.org/NumPy_for_Matlab_Users
+        https://numpy.org
+        https://numpy.org/doc/stable/user/numpy-for-matlab-users.html
     gdal: Pythonic interface to the Geospatial Data Abstraction Library (GDAL)
         https://pypi.python.org/pypi/GDAL/
     fiona: Python wrapper for vector data access functions from the OGR library

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,14 @@
 from setuptools import setup, find_packages
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 setup(
     name='read-cryosat-2',
-    version='1.0.1.4',
+    version='1.0.1.5',
     description='Reads and writes data from the ESA CryoSat-2 mission',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     url='https://github.com/tsutterley/read-cryosat-2',
     author='Tyler Sutterley',
     author_email='tsutterl@uw.edu',
@@ -12,8 +18,8 @@ setup(
         'Intended Audience :: Science/Research',
         'Topic :: Scientific/Engineering :: Physics',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.7',
     ],
     keywords='CryoSat-2 radar altimetry SIRAL',
     packages=find_packages(),


### PR DESCRIPTION
Baseline-D GDR level-2 files have `ind_first_meas_20hz_01` pointer variables that map outside the range of data. Unless I am mistaken about the GDR datasets, this is a bug with the data itself.  This fix patches to map only within each file.  It will not affect the reading of any other level-2 data.